### PR TITLE
fix: restore maxRetriesPerRequest to null for BullMQ compatibility

### DIFF
--- a/backend/src/lib/queue.ts
+++ b/backend/src/lib/queue.ts
@@ -4,7 +4,7 @@ import { env } from "../config/env";
 
 export const redisConnection = new Redis(env.REDIS_URL, {
   password: env.REDIS_PASSWORD,
-  maxRetriesPerRequest: 3,
+  maxRetriesPerRequest: null,
   lazyConnect: true,
   retryStrategy: (times) => Math.min(times * 100, 2000),
 });


### PR DESCRIPTION
BullMQ requires maxRetriesPerRequest: null on the Redis connection used by Workers (blocking commands). Changing it to 3 caused the server to crash on startup with:
  Error: BullMQ: Your redis options maxRetriesPerRequest must be null.

The retryStrategy remains in place for reconnection handling.

https://claude.ai/code/session_01AuqSWHd52JGquH3gJXyxEC