### PR TITLE
fix: stabilize ThemeContext functions with useCallback to prevent the…

### DIFF
--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 export type ThemePreset = "ocean" | "forest" | "sunset" | "violet";
 
@@ -63,21 +63,21 @@ export function ThemeProvider({ children }: PropsWithChildren) {
     localStorage.setItem("uniplanner_preset", preset);
   }, [preset]);
 
-  function toggleDark() {
+  const toggleDark = useCallback(() => {
     setIsDark((prev) => !prev);
-  }
+  }, []);
 
-  function setDarkMode(value: boolean) {
+  const setDarkMode = useCallback((value: boolean) => {
     setIsDark(value);
-  }
+  }, []);
 
-  function setPreset(p: ThemePreset) {
+  const setPreset = useCallback((p: ThemePreset) => {
     setPresetState(p);
-  }
+  }, []);
 
   const value = useMemo<ThemeContextValue>(
     () => ({ isDark, toggleDark, setDarkMode, preset, setPreset }),
-    [isDark, preset],
+    [isDark, preset, toggleDark, setDarkMode, setPreset],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;


### PR DESCRIPTION
…me reset

The dark mode toggle and color preset selectors in Settings were immediately reverting after each click.

Root cause: toggleDark/setDarkMode/setPreset were plain functions recreated on every render. The useMemo in ThemeProvider depended on [isDark, preset], so toggling dark mode created new function references. AppShell's useEffect had these functions as dependencies, so it fired on every toggle and called setDarkMode(user.darkModePref) — overwriting the new value with the stale one from the database.

Fix: wrap toggleDark, setDarkMode, and setPreset with useCallback([]) so their references are stable across renders. The AppShell effect now only fires when user.darkModePref or user.themePreset actually change in the database, not on every local toggle.

Closes #26, #27

https://claude.ai/code/session_01AuqSWHd52JGquH3gJXyxEC