### PR TITLE
fix: use valid nginx:1.27.0-alpine tag in frontend Dockerfile.prod

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -13,7 +13,7 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM nginx:1.27.0-alpine3.20 AS runtime
+FROM nginx:1.27.0-alpine AS runtime
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 # Copy as template so envsubst can inject BACKEND_INTERNAL_URL at start time.


### PR DESCRIPTION
The tag nginx:1.27.0-alpine3.20 does not exist on Docker Hub — nginx official images do not publish OS-version suffixed tags like Node.js does. Replace it with the correct nginx:1.27.0-alpine tag to fix the build.

https://claude.ai/code/session_01FMFDAofKKFCJNut1iCEYep