### PR TITLE
fix: add --accept-data-loss to prisma db push on deploy

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -32,4 +32,4 @@ USER node
 EXPOSE 4000
 # Run migrations then start the server.
 # docker-compose.prod.yml overrides this command; Render uses it directly.
-CMD ["sh", "-c", "npx prisma db push --skip-generate && node dist/server.js"]
+CMD ["sh", "-c", "npx prisma db push --skip-generate --accept-data-loss && node dist/server.js"]


### PR DESCRIPTION
The User table in production still has the longestStreak and studyStreak columns (removed from the schema) with non-null data. prisma db push blocks without --accept-data-loss; this flag explicitly acknowledges the intentional column removal.

https://claude.ai/code/session_01FMFDAofKKFCJNut1iCEYep